### PR TITLE
ci(delivery): publish to Galaxy only on new releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,8 +9,8 @@ on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
-  release:
-    name: Release
+  github:
+    name: Release to Github
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,6 +34,7 @@ jobs:
       # NOTE: The configuration file for 'semantic-release' is '.releaserc.yml'
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
+        id: semantic
         with:
           extra_plugins: |
             conventional-changelog-conventionalcommits
@@ -43,9 +44,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_REPO_FULL }}
 
-      #############################
-      # Release to Ansible Galaxy
-      #############################
+  #############################
+  # Release to Ansible Galaxy
+  #############################
+  # We depend on the github job to see if there was a new release.
+  galaxy:
+    name: Release to Galaxy
+    runs-on: ubuntu-latest
+    needs: [github]
+    if: needs.github.steps.semantic.outputs.new_release_published == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Python 3.x
         uses: actions/setup-python@v2


### PR DESCRIPTION
galaxy job runs only when github job decided a new release was required
